### PR TITLE
Update sonarcloud workflow and test sonarcloud analysis for pr

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,5 +1,9 @@
 name: SonarCloud Analysis
 on:
+  push:
+    branches:
+      - main 
+      - develop
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/src/SurveyPro.Tests/Services/SurveyParticipationServiceTests.cs
+++ b/src/SurveyPro.Tests/Services/SurveyParticipationServiceTests.cs
@@ -152,6 +152,7 @@ public class SurveyParticipationServiceTests
     [Fact]
     public async Task SaveDraftAsync_UnpublishedSurvey_ReturnsConfiguredMessage()
     {
+        // Arrange
         var dbContext = CreateDbContext();
         await SeedSessionAsync(dbContext, SurveyStatuses.Draft);
 
@@ -165,8 +166,10 @@ public class SurveyParticipationServiceTests
             Answers = new List<ParticipationAnswerDto>(),
         };
 
+        // Act
         var result = await service.SaveDraftAsync(ValidUserId, request, CancellationToken.None);
 
+        // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be(SurveyNotPublishedMessage);
     }


### PR DESCRIPTION
## Description
The SonarQube workflow has been updated to include code coverage results in code quality analysis.

## Changes

- Added parameters for passing XPlat Code Coverage results to SonarQube:
    /d:sonar.cs.opencover.reportsPaths=“**/coverage.opencover.xml” — passes coverage files
    /d:sonar.coverage.exclusions=“**Tests/**” — excludes test code from analysis
- Fixed encoding issue in Program.cs by handling invalid UTF-8 character / ensuring proper sonar.sourceEncoding
- Resolved CSS parsing issue in site.css caused by CRLF line endings — standardized file to LF
- Fixed invalid JSON in stylecop1.json by correcting syntax errors